### PR TITLE
main.js redirect broken

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,5 +17,5 @@ function getParameterByName(name) {
 }
 
 function redirect() {
-    window.location = "http://" + getParameterByName("redirect");
+    window.location = getParameterByName("redirect");
 }


### PR DESCRIPTION
This is necessary for firefox and chromium. IE untested.
